### PR TITLE
fix(Matching): Use a clean object to store the specifiers in so __pro…

### DIFF
--- a/src/babel-plugin-axiom.js
+++ b/src/babel-plugin-axiom.js
@@ -31,9 +31,9 @@ export default ({ types }) => {
     visitor: {
       Program: {
         enter() {
-          axioms = {};
-          specified = {};
-          selectedAxioms = {};
+          axioms = Object.create(null);
+          specified = Object.create(null);
+          selectedAxioms = Object.create(null);
         },
       },
 


### PR DESCRIPTION
…to__ etc... doesn't get matched